### PR TITLE
Fix type fwd float precision

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+/docs/* linguist-documentation
+* text=auto
+

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ Of course, when executed in parallel, a test suites total time is the max time o
 
 This framework is header-only. To use it, just inlude the *sctf.hpp* header file.  
 In order to use the parallelization capability compile and link the test code with *'-fopenmp'* flag. As the asserts are wrapped with macros, statements inside assert statements, that have commata itself, must be written in braces.
+As floating-point comparison relies on an, so called, epsilon, we use the machine epsilon by default. But this may lead into false-negative test results, as it could be too accurate. In order to provide a custom epsilon, provide a macro in each compilation unit, which is called `SCTF_CUSTOM_EPSILON` and set it to a satisfying value (like 0.000001).
+A compiler invocation could look like "`g++ -std=c++0x test.cpp -fopenmp -DSCTF_CUSTOM_EPSILON=0.000001`".
 
 ### Example
 

--- a/src/AssertionFailure.hpp
+++ b/src/AssertionFailure.hpp
@@ -28,7 +28,7 @@
 namespace sctf
 {
 /**
- * @brief Represent a failed assertion.
+ * @brief Thrown when an assertion fails.
  */
 class AssertionFailure : public std::exception
 {
@@ -46,8 +46,7 @@ public:
     /**
      * @brief Destructor
      */
-    ~AssertionFailure() noexcept
-    {}
+    ~AssertionFailure() noexcept = default;
 
     /**
      * @brief Get the error message.

--- a/src/assert.hpp
+++ b/src/assert.hpp
@@ -22,14 +22,12 @@
 #ifndef SCTF_SRC_ASSERT_HPP_
 #define SCTF_SRC_ASSERT_HPP_
 
-#include <string>
-
 #include "comparator/comparators.hpp"
 #include "comparator/equals.hpp"
 #include "comparator/inrange.hpp"
 #include "comparator/unequals.hpp"
-#include "util/Duration.hpp"
-#include "util/Interval.hpp"
+#include "util/duration.hpp"
+#include "util/interval.hpp"
 #include "util/serialize.hpp"
 #include "AssertionFailure.hpp"
 #include "types.h"
@@ -82,7 +80,7 @@
  * @param UPPER The upper bound
  */
 #define assertInInterval(VALUE, LOWER, UPPER) \
-    assert(VALUE, IN_RANGE, (sctf::util::Interval<decltype(LOWER)>{LOWER, UPPER}))
+    assert(VALUE, IN_RANGE, (sctf::util::interval<decltype(LOWER)>{LOWER, UPPER}))
 
 /**
  * @def assertTrue(VALUE)
@@ -148,8 +146,9 @@
 namespace sctf
 {
 /**
- * @brief Assert a value to be compared successfully to expected value.
- * @tparam T The type of value and expected
+ * @brief Assert a value to be compared successfully to an expected value.
+ * @tparam V The type of value
+ * * @tparam V The type of expect
  * @param value The actual value
  * @param expect The expected value
  * @param comp The Comparator
@@ -236,7 +235,7 @@ inline static void _assertPerformance(const test::test_function& func, double ma
 {
     try
     {
-        util::Duration dur;
+        util::duration dur;
         func();
         double dur_ms = dur.get();
         if(dur_ms > max_millis)

--- a/src/assert.hpp
+++ b/src/assert.hpp
@@ -71,7 +71,7 @@
  * @param VALUE The actual value
  * @param EXPECT The expected value
  */
-#define assertEquals(VALUE, EXPECT) assert(VALUE, EQUALS, EXPECT)
+#define assertEquals(VALUE, EXPECT) assertT(VALUE, EQUALS, EXPECT, decltype(VALUE))
 
 /**
  * @def assertInInterval(VALUE, LOWER, UPPER)

--- a/src/comparator/comparators.hpp
+++ b/src/comparator/comparators.hpp
@@ -23,7 +23,6 @@
 #define SCTF_SRC_COMPARATOR_COMPARATORS_HPP_
 
 #include <memory>
-#include <string>
 
 #include "../util/serialize.hpp"
 
@@ -124,7 +123,8 @@ private:
 /**
  * @typedef Comparator
  * @brief Function pointer to function comparing two elements
- * @tparam T The type of elements
+ * @tparam V The left hand type
+ * @tparam E The right hand type
  */
 template<typename V, typename E = V>
 using Comparator = Comparison (*)(const V&, const E&);

--- a/src/comparator/equals.hpp
+++ b/src/comparator/equals.hpp
@@ -39,7 +39,8 @@ constexpr const char* equals_comp_str = "to be equals";
 
 /**
  * @brief Check a value to be equal to an expected.
- * @note Applies to all non-floating-point types for V.
+ * @note Applies to all non-floating-point types for V, which provide an equality
+ * operator.
  * @tparam V The type of value
  * @tparam E The type of expect
  * @param value The value to check
@@ -59,7 +60,8 @@ static Comparison equals(const V& value, const E& expect)
 
 /**
  * @brief Check a value to be equal to an expected.
- * @note Applies to all non-floating-point types for V.
+ * @note Applies to all non-floating-point types for V, which don't provide an equality,
+ * but an unequality operator.
  * @tparam V The type of value
  * @tparam E The type of expect
  * @param value The value to check

--- a/src/comparator/equals.hpp
+++ b/src/comparator/equals.hpp
@@ -27,13 +27,14 @@
 #include <limits>
 #include <type_traits>
 
+#include "../util/traits.hpp"
 #include "comparators.hpp"
 
 namespace sctf
 {
 namespace comp
 {
-/// @brief constraint string
+/// @brief The constraint string for equals.
 constexpr const char* equals_comp_str = "to be equals";
 
 /**
@@ -45,13 +46,36 @@ constexpr const char* equals_comp_str = "to be equals";
  * @param expect The expected value
  * @return true if value is equals expect, else false
  */
-template<typename V, typename E = V,
-         typename std::enable_if<not std::is_floating_point<V>::value>::type* = nullptr>
+template<
+    typename V, typename E = V,
+    typename std::enable_if<not std::is_floating_point<V>::value
+                            and util::is_equal_comparable<V, E>::value>::type* = nullptr>
 static Comparison equals(const V& value, const E& expect)
 {
-    return (value == expect) ? success
-                             : Comparison(equals_comp_str, util::serialize(value),
-                                          util::serialize(expect));
+    return value == expect ? success
+                           : Comparison(equals_comp_str, util::serialize(value),
+                                        util::serialize(expect));
+}
+
+/**
+ * @brief Check a value to be equal to an expected.
+ * @note Applies to all non-floating-point types for V.
+ * @tparam V The type of value
+ * @tparam E The type of expect
+ * @param value The value to check
+ * @param expect The expected value
+ * @return true if value is equals expect, else false
+ */
+template<typename V, typename E = V,
+         typename std::enable_if<
+             not std::is_floating_point<V>::value
+             and not util::is_equal_comparable<V, E>::value
+             and util::is_unequal_comparable<V, E>::value>::type* = nullptr>
+static Comparison equals(const V& value, const E& expect)
+{
+    return value != expect ? Comparison(equals_comp_str, util::serialize(value),
+                                        util::serialize(expect))
+                           : success;
 }
 
 /**

--- a/src/comparator/inrange.hpp
+++ b/src/comparator/inrange.hpp
@@ -24,8 +24,8 @@
 
 #include <algorithm>
 #include <utility>
+
 #include "../util/Interval.hpp"
-#include "../util/serialize.hpp"
 #include "../util/traits.hpp"
 #include "comparators.hpp"
 
@@ -72,13 +72,30 @@ Comparison in_range(const V& value, const R& range)
  */
 template<
     typename V, typename R,
-    typename std::enable_if<std::is_same<R, std::pair<V, V>>::value>::type* = nullptr>
+    typename std::enable_if<std::is_same<R, std::pair<V, V>>::value
+                            and util::is_equal_comparable<V, V>::value>::type* = nullptr>
 Comparison in_range(const V& value, const R& range)
 {
     return value == range.first || value == range.second
                ? success
                : Comparison(in_range_comp_str, util::serialize(value),
                             util::serialize(range));
+}
+
+/**
+ * @brief Check for pair to contain an appropriate value.
+ */
+template<typename V, typename R,
+         typename std::enable_if<
+             std::is_same<R, std::pair<V, V>>::value
+             and not util::is_equal_comparable<V, V>::value
+             and util::is_unequal_comparable<V, V>::value>::type* = nullptr>
+Comparison in_range(const V& value, const R& range)
+{
+    return value != range.first && value != range.second
+               ? Comparison(in_range_comp_str, util::serialize(value),
+                            util::serialize(range))
+               : success;
 }
 
 /**

--- a/src/comparator/inrange.hpp
+++ b/src/comparator/inrange.hpp
@@ -25,7 +25,7 @@
 #include <algorithm>
 #include <utility>
 
-#include "../util/Interval.hpp"
+#include "../util/interval.hpp"
 #include "../util/traits.hpp"
 #include "comparators.hpp"
 
@@ -33,14 +33,16 @@ namespace sctf
 {
 namespace comp
 {
-/// @brief constraint string
+/// @brief The constraint string for in_range.
 constexpr const char* in_range_comp_str = "to be in range of";
 
 /**
  * @brief Check for iterable non-string types to contain a value.
- * @tparam V The value to check
- * @tparam R The range/container to search
- * @return Whether the value was found
+ * @tparam V The value type
+ * @tparam R The range/container type
+ * @param value The value to check
+ * @param range The range/container to search
+ * @return whether the value was found
  */
 template<
     typename V, typename R,
@@ -55,7 +57,12 @@ static Comparison in_range(const V& value, const R& range)
 }
 
 /**
- * @brief Check for string types to contain an appropriate value.
+ * @brief Check for string types to contain a value.
+ * @tparam V The value type
+ * @tparam R The range/container type
+ * @param value The value to check
+ * @param range The range/container to search
+ * @return whether the value was found
  */
 template<typename V, typename R = V,
          typename std::enable_if<std::is_same<R, std::string>::value>::type* = nullptr>
@@ -68,7 +75,13 @@ Comparison in_range(const V& value, const R& range)
 }
 
 /**
- * @brief Check for pair to contain an appropriate value.
+ * @brief Check for pair to contain a value, where the value provides an equality
+ * operator.
+ * @tparam V The value type
+ * @tparam R The range/container type
+ * @param value The value to check
+ * @param range The range/container to search
+ * @return whether the value was found
  */
 template<
     typename V, typename R,
@@ -83,7 +96,13 @@ Comparison in_range(const V& value, const R& range)
 }
 
 /**
- * @brief Check for pair to contain an appropriate value.
+ * @brief Check for pair to contain a value, where the value provides an unequality, but
+ * no equality operator.
+ * @tparam V The value type
+ * @tparam R The range/container type
+ * @param value The value to check
+ * @param range The range/container to search
+ * @return whether the value was found
  */
 template<typename V, typename R,
          typename std::enable_if<
@@ -99,12 +118,16 @@ Comparison in_range(const V& value, const R& range)
 }
 
 /**
- * @brief Check for a value to be in Interval's lower and upper
- * bounds.
+ * @brief Check for a value to be in interval's lower and upper bounds.
+ * @tparam V The value type
+ * @tparam R The range/container type
+ * @param value The value to check
+ * @param range The range/container to search
+ * @return whether the value was found
  */
 template<
     typename V, typename R,
-    typename std::enable_if<std::is_same<R, util::Interval<V>>::value>::type* = nullptr>
+    typename std::enable_if<std::is_same<R, util::interval<V>>::value>::type* = nullptr>
 Comparison in_range(const V& value, const R& bounds)
 {
     return value < bounds.lower || value > bounds.upper

--- a/src/comparator/unequals.hpp
+++ b/src/comparator/unequals.hpp
@@ -26,13 +26,14 @@
 #include <cmath>
 #include <limits>
 
+#include "../util/traits.hpp"
 #include "comparators.hpp"
 
 namespace sctf
 {
 namespace comp
 {
-/// @brief constraint string
+/// @brief The constraint string for unequals.
 constexpr const char* unequals_comp_str = "to be unequals";
 
 /**
@@ -45,12 +46,35 @@ constexpr const char* unequals_comp_str = "to be unequals";
  * @return true if value is unequals expect, else false
  */
 template<typename V, typename E = V,
-         typename std::enable_if<not std::is_floating_point<V>::value>::type* = nullptr>
+         typename std::enable_if<
+             not std::is_floating_point<V>::value
+             and util::is_unequal_comparable<V, E>::value>::type* = nullptr>
 static Comparison unequals(const V& value, const E& expect)
 {
-    return (value != expect) ? success
-                             : Comparison(unequals_comp_str, util::serialize(value),
-                                          util::serialize(expect));
+    return value != expect ? success
+                           : Comparison(unequals_comp_str, util::serialize(value),
+                                        util::serialize(expect));
+}
+
+/**
+ * @brief Check a value to be unequal to an expected.
+ * @note Applies to all non-floating-point types for V.
+ * @tparam V The type of value
+ * @tparam E The type of expect
+ * @param value The value to check
+ * @param expect The expected value
+ * @return true if value is unequals expect, else false
+ */
+template<
+    typename V, typename E = V,
+    typename std::enable_if<not std::is_floating_point<V>::value
+                            and not util::is_unequal_comparable<V, E>::value
+                            and util::is_equal_comparable<V, E>::value>::type* = nullptr>
+static Comparison unequals(const V& value, const E& expect)
+{
+    return value == expect ? Comparison(unequals_comp_str, util::serialize(value),
+                                        util::serialize(expect))
+                           : success;
 }
 
 /**

--- a/src/comparator/unequals.hpp
+++ b/src/comparator/unequals.hpp
@@ -28,31 +28,51 @@
 
 #include "comparators.hpp"
 
-/**
- * Define an unequals comparator.
- */
-COMPARATOR(unequals, "to be unequals", value != expect)
-
-/**
- * Provide a Comparator shortwrite.
- */
-PROVIDE_COMPARATOR(unequals, UNEQUALS)
-PROVIDE_COMPARATOR(unequals, NE)
-
 namespace sctf
 {
 namespace comp
 {
+/// @brief constraint string
+constexpr const char* unequals_comp_str = "to be unequals";
+
 /**
- * Specialized unequals for type 'double'.
- * Takes care about floating point precision.
+ * @brief Check a value to be unequal to an expected.
+ * @note Applies to all non-floating-point types for V.
+ * @tparam V The type of value
+ * @tparam E The type of expect
+ * @param value The value to check
+ * @param expect The expected value
+ * @return true if value is unequals expect, else false
  */
-template<typename T,
-         typename std::enable_if<std::is_floating_point<T>::value>::type* = nullptr>
-Comparison unequals(const T& value, const T& expect)
+template<typename V, typename E = V,
+         typename std::enable_if<not std::is_floating_point<V>::value>::type* = nullptr>
+static Comparison unequals(const V& value, const E& expect)
 {
-    return (std::abs(value - expect) <= std::max(std::abs(value), std::abs(expect))
-                                            * std::numeric_limits<T>::epsilon())
+    return (value != expect) ? success
+                             : Comparison(unequals_comp_str, util::serialize(value),
+                                          util::serialize(expect));
+}
+
+/**
+ * @brief Check a value to be unequal to an expected.
+ * @note Applies to all floating-point types for V.
+ * @tparam V The type of value
+ * @tparam E The type of expect
+ * @param value The value to check
+ * @param expect The expected value
+ * @return true if value is unequals expect, else false
+ */
+template<typename V, typename E = V,
+         typename std::enable_if<std::is_floating_point<V>::value>::type* = nullptr>
+Comparison unequals(const V& value, const E& expect)
+{
+#ifdef SCTF_CUSTOM_EPSILON
+    static V epsilon = SCTF_CUSTOM_EPSILON;
+#else
+    static V epsilon = std::numeric_limits<V>::epsilon();
+#endif
+    return (std::abs(value - expect)
+            <= std::max(std::abs(value), std::abs(expect)) * epsilon)
                ? Comparison(unequals_comp_str, util::serialize(value),
                             util::serialize(expect))
                : success;
@@ -60,5 +80,11 @@ Comparison unequals(const T& value, const T& expect)
 
 }  // namespace comp
 }  // namespace sctf
+
+/**
+ * Provide a Comparator shortwrite.
+ */
+PROVIDE_COMPARATOR(unequals, UNEQUALS)
+PROVIDE_COMPARATOR(unequals, NE)
 
 #endif  // SCTF_SRC_COMPARATOR_UNEQUALS_HPP_

--- a/src/comparator/unequals.hpp
+++ b/src/comparator/unequals.hpp
@@ -38,7 +38,8 @@ constexpr const char* unequals_comp_str = "to be unequals";
 
 /**
  * @brief Check a value to be unequal to an expected.
- * @note Applies to all non-floating-point types for V.
+ * @note Applies to all non-floating-point types for V, which provide an unequality
+ * operator.
  * @tparam V The type of value
  * @tparam E The type of expect
  * @param value The value to check
@@ -58,7 +59,8 @@ static Comparison unequals(const V& value, const E& expect)
 
 /**
  * @brief Check a value to be unequal to an expected.
- * @note Applies to all non-floating-point types for V.
+ * @note Applies to all non-floating-point types for V, which provide an equality, but no
+ * unequality operator.
  * @tparam V The type of value
  * @tparam E The type of expect
  * @param value The value to check

--- a/src/reporter/AbstractReporter.hpp
+++ b/src/reporter/AbstractReporter.hpp
@@ -119,8 +119,7 @@ protected:
     /**
      * @brief Destructor
      */
-    virtual ~AbstractReporter() noexcept
-    {}
+    virtual ~AbstractReporter() noexcept = default;
 
     /**
      * @brief Generate report for a given TestSuite.

--- a/src/reporter/HtmlReporter.hpp
+++ b/src/reporter/HtmlReporter.hpp
@@ -78,8 +78,7 @@ public:
     /**
      * @brief Destructor
      */
-    ~HtmlReporter() noexcept
-    {}
+    ~HtmlReporter() noexcept = default;
 
 private:
     /**

--- a/src/reporter/PlainTextReporter.hpp
+++ b/src/reporter/PlainTextReporter.hpp
@@ -72,8 +72,7 @@ public:
     /**
      * @brief Destructor
      */
-    ~PlainTextReporter() noexcept
-    {}
+    ~PlainTextReporter() noexcept = default;
 
 private:
     /**

--- a/src/reporter/XmlReporter.hpp
+++ b/src/reporter/XmlReporter.hpp
@@ -55,14 +55,13 @@ public:
      * @brief Constructor
      * @param fname The file to write to
      */
-    explicit XmlReporter(const char* fnam) : AbstractReporter(fnam)
+    explicit XmlReporter(const char* fname) : AbstractReporter(fname)
     {}
 
     /**
      * @brief Destructor
      */
-    ~XmlReporter() noexcept
-    {}
+    ~XmlReporter() noexcept = default;
 
 private:
     /**

--- a/src/testsuite/TestCase.hpp
+++ b/src/testsuite/TestCase.hpp
@@ -28,7 +28,7 @@
 
 #include "../AssertionFailure.hpp"
 #include "../types.h"
-#include "../util/Duration.hpp"
+#include "../util/duration.hpp"
 
 namespace sctf
 {
@@ -73,8 +73,7 @@ public:
     /**
      * @brief Destructor
      */
-    ~TestCase() noexcept
-    {}
+    ~TestCase() noexcept = default;
 
     /**
      * @brief Move-assignment
@@ -114,7 +113,7 @@ public:
     void operator()()
     {
         if(m_state != State::NONE) return;
-        util::Duration dur;
+        util::duration dur;
         try
         {
             m_test_func();

--- a/src/testsuite/TestStats.hpp
+++ b/src/testsuite/TestStats.hpp
@@ -40,14 +40,12 @@ public:
     /**
      * @brief Constructor
      */
-    TestStats()
-    {}
+    TestStats() = default;
 
     /**
      * @brief Destructor
      */
-    ~TestStats() noexcept
-    {}
+    ~TestStats() noexcept = default;
 
     /**
      * @brief Get the number of all tests.

--- a/src/testsuite/TestSuite.hpp
+++ b/src/testsuite/TestSuite.hpp
@@ -76,8 +76,7 @@ public:
     /**
      * @brief Destructor
      */
-    virtual ~TestSuite() noexcept
-    {}
+    virtual ~TestSuite() noexcept = default;
 
     /**
      * @brief Execute all TestCases sequentially.

--- a/src/testsuite/TestSuiteParallel.hpp
+++ b/src/testsuite/TestSuiteParallel.hpp
@@ -52,8 +52,7 @@ public:
     /**
      * @brief Destructor
      */
-    ~TestSuiteParallel() noexcept
-    {}
+    ~TestSuiteParallel() noexcept = default;
 
     /**
      * @brief Execute all TestCases in parallel.

--- a/src/testsuite/TestSuitesRunner.hpp
+++ b/src/testsuite/TestSuitesRunner.hpp
@@ -46,14 +46,12 @@ public:
     /**
      * @brief Constructor
      */
-    TestSuitesRunner()
-    {}
+    TestSuitesRunner() = default;
 
     /**
      * @brief Destructor
      */
-    ~TestSuitesRunner() noexcept
-    {}
+    ~TestSuitesRunner() noexcept = default;
 
     /**
      * @brief Register a TestSuite.

--- a/src/util/duration.hpp
+++ b/src/util/duration.hpp
@@ -19,39 +19,51 @@
  }
  */
 
-#ifndef SCTF_SRC_UTIL_INTERVAL_HPP_
-#define SCTF_SRC_UTIL_INTERVAL_HPP_
+#ifndef SCTF_SRC_UTIL_DURATION_HPP_
+#define SCTF_SRC_UTIL_DURATION_HPP_
 
-#include "traits.hpp"
+#include <chrono>
+#include <cstdint>
 
 namespace sctf
 {
 namespace util
 {
 /**
- * @brief A utility used for bounds checking for in_range comparator.
- * @tparam T The type used as bounds
- * @note T must provide ordinal relation with operators < and >.
+ * @brief Measure time in milliseconds.
+ * @note The start timepoint is fixed upon construction.
  */
-template<typename T, typename std::enable_if<is_ordinal<T>::value>::type* = nullptr>
-struct Interval final
+struct duration final
 {
     /**
      * @brief Constructor
-     * @param l The lower bounds
-     * @param u The upper bounds
      */
-    Interval(const T& l, const T& u) : lower(l), upper(u)
+    duration() : _start(std::chrono::steady_clock::now())
     {}
 
-    /// @brief The lower bounds
-    const T lower;
+    /**
+     * @brief Destructor
+     */
+    ~duration() noexcept
+    {}
 
-    /// @brief The upper bounds
-    const T upper;
+    /**
+     * @brief Get the actual duration since start time in milliseconds.
+     * @return the milliseconds
+     */
+    double get()
+    {
+        return std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now()
+                                                         - _start)
+            .count();
+    }
+
+private:
+    /// @brief start timepoint
+    const std::chrono::steady_clock::time_point _start;
 };
 
 }  // namespace util
 }  // namespace sctf
 
-#endif  // SCTF_SRC_UTIL_INTERVAL_HPP_
+#endif  // SCTF_SRC_UTIL_DURATION_HPP_

--- a/src/util/interval.hpp
+++ b/src/util/interval.hpp
@@ -19,51 +19,39 @@
  }
  */
 
-#ifndef SCTF_SRC_UTIL_DURATION_HPP_
-#define SCTF_SRC_UTIL_DURATION_HPP_
+#ifndef SCTF_SRC_UTIL_INTERVAL_HPP_
+#define SCTF_SRC_UTIL_INTERVAL_HPP_
 
-#include <chrono>
-#include <cstdint>
+#include "traits.hpp"
 
 namespace sctf
 {
 namespace util
 {
 /**
- * @brief Measure time in milliseconds.
- * @note The start timepoint is fixed upon construction.
+ * @brief A utility used for bounds checking for in_range comparator.
+ * @tparam T The type used as bounds
+ * @note T must provide ordinal relation with operators < and >.
  */
-struct Duration final
+template<typename T, typename std::enable_if<is_ordinal<T>::value>::type* = nullptr>
+struct interval final
 {
     /**
      * @brief Constructor
+     * @param l The lower bounds
+     * @param u The upper bounds
      */
-    Duration() : _start(std::chrono::steady_clock::now())
+    interval(const T& l, const T& u) : lower(l), upper(u)
     {}
 
-    /**
-     * @brief Destructor
-     */
-    ~Duration() noexcept
-    {}
+    /// @brief The lower bounds
+    const T lower;
 
-    /**
-     * @brief Get duration since start time in milliseconds.
-     * @return the milliseconds
-     */
-    double get()
-    {
-        return std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now()
-                                                         - _start)
-            .count();
-    }
-
-private:
-    /// @brief start timepoint
-    const std::chrono::steady_clock::time_point _start;
+    /// @brief The upper bounds
+    const T upper;
 };
 
 }  // namespace util
 }  // namespace sctf
 
-#endif  // SCTF_SRC_UTIL_DURATION_HPP_
+#endif  // SCTF_SRC_UTIL_INTERVAL_HPP_

--- a/src/util/serialize.hpp
+++ b/src/util/serialize.hpp
@@ -30,7 +30,7 @@
 #include <typeinfo>
 #include <utility>
 
-#include "Interval.hpp"
+#include "interval.hpp"
 #include "traits.hpp"
 
 namespace sctf
@@ -81,7 +81,7 @@ inline std::string serialize(const T& arg)
 }
 
 /**
- * @brief Serialize streamable types.
+ * @brief Serialize floating-point types.
  * @tparam T The type
  * @param arg The element to serialize
  * @return the element as string
@@ -98,6 +98,9 @@ inline std::string serialize(const T& arg)
 
 /**
  * @brief Serialize not streamable types.
+ * @tparam T The type
+ * @param unused
+ * @return the element as string
  */
 template<typename T, typename std::enable_if<not is_streamable<
                          std::ostringstream, T>::value>::type* = nullptr>
@@ -108,6 +111,8 @@ inline std::string serialize(const T&)
 
 /**
  * @brief Specialized serialize for strings (dummy).
+ * @param arg The string to serialize
+ * @return the string
  */
 template<>
 inline std::string serialize(const std::string& arg)
@@ -117,6 +122,8 @@ inline std::string serialize(const std::string& arg)
 
 /**
  * @brief Specialized serialize for C-strings.
+ * @param arg The C-string to serialize
+ * @return the C-string as string
  */
 template<>
 inline std::string serialize(const char* const& arg)
@@ -126,6 +133,8 @@ inline std::string serialize(const char* const& arg)
 
 /**
  * @brief Specialized serialize for nullptr.
+ * @param unused
+ * @return "0"
  */
 template<>
 inline std::string serialize(const std::nullptr_t&)
@@ -135,6 +144,9 @@ inline std::string serialize(const std::nullptr_t&)
 
 /**
  * @brief Specialized serialize for pairs.
+ * @tparam T The type inside pair
+ * @param arg The pair to serialize
+ * @return the pair as string
  */
 template<typename T>
 inline std::string serialize(const std::pair<T, T>& arg)
@@ -144,10 +156,13 @@ inline std::string serialize(const std::pair<T, T>& arg)
 }
 
 /**
- * @brief Specialized serialize for Intervals.
+ * @brief Specialized serialize for intervals.
+ * @tparam T The type inside interval
+ * @param arg The interval to serialize
+ * @return the interval as string
  */
 template<typename T>
-inline std::string serialize(const Interval<T>& arg)
+inline std::string serialize(const interval<T>& arg)
 {
     return std::string("[") + serialize(arg.lower) + ", " + serialize(arg.upper) + "]";
 }

--- a/src/util/serialize.hpp
+++ b/src/util/serialize.hpp
@@ -23,10 +23,13 @@
 #define SCTF_SRC_UTIL_SERIALIZE_HPP_
 
 #include <cstddef>
+#include <iomanip>
+#include <limits>
 #include <sstream>
 #include <string>
 #include <typeinfo>
 #include <utility>
+
 #include "Interval.hpp"
 #include "traits.hpp"
 
@@ -68,11 +71,28 @@ static const std::string& name_for_type()
  * @return the element as string
  */
 template<typename T, typename std::enable_if<
-                         is_streamable<std::ostringstream, T>::value>::type* = nullptr>
+                         is_streamable<std::ostringstream, T>::value
+                         and not std::is_floating_point<T>::value>::type* = nullptr>
 inline std::string serialize(const T& arg)
 {
     std::ostringstream oss;
     oss << arg;
+    return oss.str();
+}
+
+/**
+ * @brief Serialize streamable types.
+ * @tparam T The type
+ * @param arg The element to serialize
+ * @return the element as string
+ */
+template<typename T,
+         typename std::enable_if<is_streamable<std::ostringstream, T>::value
+                                 and std::is_floating_point<T>::value>::type* = nullptr>
+inline std::string serialize(const T& arg)
+{
+    std::ostringstream oss;
+    oss << std::setprecision(std::numeric_limits<T>::max_digits10) << arg;
     return oss.str();
 }
 

--- a/src/util/traits.hpp
+++ b/src/util/traits.hpp
@@ -87,6 +87,44 @@ public:
     static const bool value = decltype(test<T>(0))::value;
 };
 
+/**
+ * @brief Type trait to check for streaming operator compatibility.
+ * @tparam S The stream type
+ * @tparam T The type to check for
+ */
+template<typename S, typename T>
+class is_equal_comparable
+{
+    template<typename SS, typename TT>
+    static auto test(int)
+        -> decltype(std::declval<SS&>() == std::declval<TT&>(), std::true_type());
+
+    template<typename, typename>
+    static auto test(...) -> std::false_type;
+
+public:
+    static const bool value = decltype(test<S, T>(0))::value;
+};
+
+/**
+ * @brief Type trait to check for streaming operator compatibility.
+ * @tparam S The stream type
+ * @tparam T The type to check for
+ */
+template<typename S, typename T>
+class is_unequal_comparable
+{
+    template<typename SS, typename TT>
+    static auto test(int)
+        -> decltype(std::declval<SS&>() != std::declval<TT&>(), std::true_type());
+
+    template<typename, typename>
+    static auto test(...) -> std::false_type;
+
+public:
+    static const bool value = decltype(test<S, T>(0))::value;
+};
+
 }  // namespace util
 }  // namespace sctf
 

--- a/src/util/traits.hpp
+++ b/src/util/traits.hpp
@@ -88,9 +88,9 @@ public:
 };
 
 /**
- * @brief Type trait to check for streaming operator compatibility.
- * @tparam S The stream type
- * @tparam T The type to check for
+ * @brief Type trait to check for equality operator compatibility.
+ * @tparam S The left hand type
+ * @tparam T The right hand type
  */
 template<typename S, typename T>
 class is_equal_comparable
@@ -107,9 +107,9 @@ public:
 };
 
 /**
- * @brief Type trait to check for streaming operator compatibility.
- * @tparam S The stream type
- * @tparam T The type to check for
+ * @brief Type trait to check for unequality operator compatibility.
+ * @tparam S The left hand type
+ * @tparam T The right hand type
  */
 template<typename S, typename T>
 class is_unequal_comparable


### PR DESCRIPTION
## Summary

Appropriate (un-)equal comparators were not used for floats.
Assertion "assertEquals" was not properly forwarding types.

## Main changes

Fixed above issues.

## Related Issues/Milestones


## Severity

essential

## Note

(Optional notes to add)