### PR TITLE
Enhance custom epsilon

### DIFF
--- a/src/comparator/equals.hpp
+++ b/src/comparator/equals.hpp
@@ -93,12 +93,15 @@ template<typename V, typename E = V,
                                  std::is_floating_point<E>::value>::type* = nullptr>
 Comparison equals(const V& value, const E& expect)
 {
-#ifdef SCTF_CUSTOM_EPSILON
-    static V epsilon = SCTF_CUSTOM_EPSILON;
+#ifdef SCTF_EPSILON
+    static V epsilon_ = SCTF_EPSILON;
+#elif defined(SCTF_EXTERN_EPSILON)
+    extern double epsilon;
+    static V      epsilon_ = static_cast<V>(epsilon);
 #else
-    static V epsilon = std::numeric_limits<V>::epsilon();
+    static V epsilon_ = std::numeric_limits<V>::epsilon();
 #endif
-    return (std::abs(value - expect) <= std::max(std::abs(value), std::abs(expect)) * epsilon) ?
+    return (std::abs(value - expect) <= std::max(std::abs(value), std::abs(expect)) * epsilon_) ?
                success :
                Comparison(equals_comp_str, util::serialize(value), util::serialize(expect));
 }

--- a/src/comparator/unequals.hpp
+++ b/src/comparator/unequals.hpp
@@ -92,12 +92,15 @@ template<typename V, typename E = V,
                                  std::is_floating_point<E>::value>::type* = nullptr>
 Comparison unequals(const V& value, const E& expect)
 {
-#ifdef SCTF_CUSTOM_EPSILON
-    static V epsilon = SCTF_CUSTOM_EPSILON;
+#ifdef SCTF_EPSILON
+    static V epsilon_ = SCTF_EPSILON;
+#elif defined(SCTF_EXTERN_EPSILON)
+    extern double epsilon;
+    static V      epsilon_ = static_cast<V>(epsilon);
 #else
-    static V epsilon = std::numeric_limits<V>::epsilon();
+    static V epsilon_ = std::numeric_limits<V>::epsilon();
 #endif
-    return (std::abs(value - expect) <= std::max(std::abs(value), std::abs(expect)) * epsilon) ?
+    return (std::abs(value - expect) <= std::max(std::abs(value), std::abs(expect)) * epsilon_) ?
                Comparison(unequals_comp_str, util::serialize(value), util::serialize(expect)) :
                success;
 }

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -22,6 +22,7 @@
 #include <iostream>
 
 #include "../sctf.hpp"
+
 #include "basic_tests.h"
 #include "reflexive_tests.h"
 
@@ -30,17 +31,17 @@ using namespace sctf;
 int main(int, char**)
 {
     test::TestSuitesRunner runner;
-    auto rep = createPlainTextReporter(true);
+    auto                   rep = createPlainTextReporter(true);
     try
     {
         basic_tests();
     }
-    catch(const std::exception& e)
+    catch (const std::exception& e)
     {
         std::cout << "Basic tests have failed! [" << e.what() << "]" << std::endl;
         return 1;
     }
-    catch(...)
+    catch (...)
     {
         std::cout << "Basic tests have failed!" << std::endl;
         return 1;

--- a/test/reflexive_tests.cpp
+++ b/test/reflexive_tests.cpp
@@ -32,6 +32,14 @@
 
 #include "traits.hpp"
 
+namespace sctf
+{
+namespace comp
+{
+double epsilon = 0.000001;
+}  // namespace comp
+}  // namespace sctf
+
 using namespace sctf;
 using namespace util;
 using namespace test;

--- a/test/reflexive_tests.h
+++ b/test/reflexive_tests.h
@@ -22,6 +22,9 @@
 #ifndef TEST_REFLEXIVE_TESTS_H_
 #define TEST_REFLEXIVE_TESTS_H_
 
+#define SCTF_EXTERN_EPSILON
+//#define SCTF_EPSILON 0.000001
+
 #include "../sctf.hpp"
 
 void reflexive_tests(sctf::test::TestSuitesRunner& runner);


### PR DESCRIPTION
## Summary

Allow to set comparator epsilon via macro and extern var.

## Main changes

+ selectively use epsilon in comparators
+ allow to set epsilon via extern var

## Related Issues/Milestones

+ https://github.com/Jarthianur/simple-cpp-test-framework/issues/14
+ https://github.com/Jarthianur/simple-cpp-test-framework/milestone/1

## Severity

normal

## Note
