### PR TITLE
fix windows build on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,8 +60,6 @@ matrix:
     - BADGE=windows
     script:
     - cmd.exe //C 'build.bat'
-    - test/cpp11_seq.exe
-    - test/cpp11_par.exe
     - test/cpp14_seq.exe
     - test/cpp14_par.exe
     - test/cpp17_seq.exe

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ matrix:
     env:
     - BADGE=windows
     script:
-    - cmd.exe /C 'build.bat'
+    - cmd.exe //C 'build.bat'
     - test/cpp11_seq.exe
     - test/cpp11_par.exe
     - test/cpp14_seq.exe

--- a/build.bat
+++ b/build.bat
@@ -8,8 +8,6 @@ set CL_ARGS=/GS /Zi /Od /W3 /WX /wd4996 /FC /EHsc /nologo /I..\include
 set CL_FILES=main.cpp reflexive_tests.cpp basic_tests.cpp user_tests.cpp
 
 pushd test
-cl %CL_ARGS% /Zc:__cplusplus         %CL_FILES% /link /out:cpp11_seq.exe
-cl %CL_ARGS% /Zc:__cplusplus /openmp %CL_FILES% /link /out:cpp11_par.exe
 cl %CL_ARGS% /std:c++14              %CL_FILES% /link /out:cpp14_seq.exe
 cl %CL_ARGS% /std:c++14      /openmp %CL_FILES% /link /out:cpp14_par.exe
 cl %CL_ARGS% /std:c++17              %CL_FILES% /link /out:cpp17_seq.exe

--- a/build.bat
+++ b/build.bat
@@ -8,10 +8,10 @@ set CL_ARGS=/GS /Zi /Od /W3 /WX /wd4996 /FC /EHsc /nologo /I..\include
 set CL_FILES=main.cpp reflexive_tests.cpp basic_tests.cpp user_tests.cpp
 
 pushd test
-cl %CL_ARGS%                    %CL_FILES% /link /out:cpp11_seq.exe
-cl %CL_ARGS%            /openmp %CL_FILES% /link /out:cpp11_par.exe
-cl %CL_ARGS% /std:c++14         %CL_FILES% /link /out:cpp14_seq.exe
-cl %CL_ARGS% /std:c++14 /openmp %CL_FILES% /link /out:cpp14_par.exe
-cl %CL_ARGS% /std:c++17         %CL_FILES% /link /out:cpp17_seq.exe
-cl %CL_ARGS% /std:c++17 /openmp %CL_FILES% /link /out:cpp17_par.exe
+cl %CL_ARGS% /Zc:__cplusplus         %CL_FILES% /link /out:cpp11_seq.exe
+cl %CL_ARGS% /Zc:__cplusplus /openmp %CL_FILES% /link /out:cpp11_par.exe
+cl %CL_ARGS% /std:c++14              %CL_FILES% /link /out:cpp14_seq.exe
+cl %CL_ARGS% /std:c++14      /openmp %CL_FILES% /link /out:cpp14_par.exe
+cl %CL_ARGS% /std:c++17              %CL_FILES% /link /out:cpp17_seq.exe
+cl %CL_ARGS% /std:c++17      /openmp %CL_FILES% /link /out:cpp17_par.exe
 popd

--- a/build.bat
+++ b/build.bat
@@ -4,7 +4,7 @@ call "C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\Common7\Too
 call "C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\Common7\Tools\VsDevCmd.bat" -test
 where cl >nul 2>nul
 IF %ERRORLEVEL% NEQ 0 (echo ERROR: cl is not in PATH) && exit 1
-set CL_ARGS=/GS /Zi /Od /W3 /WX /wd4996 /FC /EHsc /nologo /I..\include
+set CL_ARGS=/GS /Zi /Od /W3 /WX /wd4996 /FC /EHsc /nologo /Zc:__cplusplus /I..\include
 set CL_FILES=main.cpp reflexive_tests.cpp basic_tests.cpp user_tests.cpp
 
 pushd test


### PR DESCRIPTION
## Summary

Windows build on travis stopped working. This needs to be corrected.

## Main changes

Change build pipeline to work again for windows.

## Related Issues/Milestones

