### PR TITLE
print exception message if caught on failure

### DIFF
--- a/include/assert.hpp
+++ b/include/assert.hpp
@@ -29,6 +29,7 @@
 #include "assertion_failure.hpp"
 #include "duration.hpp"
 #include "loc.hpp"
+#include "stringify.hpp"
 #include "traits.hpp"
 
 /**
@@ -237,7 +238,9 @@ auto assert_throws(F&& fn_, char const* tname_, loc const& loc_) -> T {
     } catch (T const& e) {
         return e;
     } catch (std::exception const& e) {
-        throw assertion_failure("Wrong exception thrown, caught " + to_string(e), loc_);
+        throw assertion_failure("Wrong exception thrown, caught " + to_string(e) + "(\"" +
+                                    escaped_string(e.what()) + "\")",
+                                loc_);
     } catch (...) {
         throw assertion_failure("Wrong exception thrown", loc_);
     }
@@ -258,7 +261,9 @@ auto assert_nothrow(F&& fn_, loc const& loc_) -> decltype(fn_()) {
     try {
         return fn_();
     } catch (std::exception const& e) {
-        throw assertion_failure("Expected no exception, caught " + to_string(e), loc_);
+        throw assertion_failure("Expected no exception, caught " + to_string(e) + "(\"" +
+                                    escaped_string(e.what()) + "\")",
+                                loc_);
     } catch (...) {
         throw assertion_failure("Expected no exception", loc_);
     }
@@ -277,7 +282,9 @@ void assert_nothrow(F&& fn_, loc const& loc_) {
     try {
         fn_();
     } catch (std::exception const& e) {
-        throw assertion_failure("Expected no exception, caught " + to_string(e), loc_);
+        throw assertion_failure("Expected no exception, caught " + to_string(e) + "(\"" +
+                                    escaped_string(e.what()) + "\")",
+                                loc_);
     } catch (...) {
         throw assertion_failure("Expected no exception", loc_);
     }


### PR DESCRIPTION
## Summary

Assertion failure message contains exception message.

## Main changes

If any exception derived from `std::exception` is caught in assertions, put the message returned by `what` into the failure message.

## Related Issues/Milestones

