### PR TITLE
Use cxxabi for unix

### DIFF
--- a/include/sctf.hpp
+++ b/include/sctf.hpp
@@ -44,9 +44,9 @@
  *
  * @param R is the reporters factory method invokation.
  */
-#define SCTF_DEFAULT_MAIN(R)                                       \
-    auto main(int /*argc*/, char* * /*argv*/)->int {               \
-        return static_cast<int>(sctf::runner::instance()->run(R)); \
+#define SCTF_DEFAULT_MAIN(R)                                      \
+    auto main(int /*argc*/, char** /*argv*/)->int {               \
+        return static_cast<int>(sctf::runner::instance().run(R)); \
     }
 
 #endif  // SCTF_SCTF_HPP

--- a/include/stringify.hpp
+++ b/include/stringify.hpp
@@ -51,17 +51,17 @@ namespace intern
  */
 template<typename T>
 static auto
-name_for_type() -> std::string const& {
+name_for_type(T const& arg_) -> std::string const& {
     static thread_local std::string name;
     if (!name.empty()) {
         return name;
     }
 #ifdef SCTF_SYS_UNIX
     int                     status = -1;
-    std::unique_ptr<char[]> sig(abi::__cxa_demangle(typeid(T).name(), nullptr, nullptr, &status));
+    std::unique_ptr<char[]> sig(abi::__cxa_demangle(typeid(arg_).name(), nullptr, nullptr, &status));
     name = sig.get();
 #else
-    name = typeid(T).name();
+    name = typeid(arg_).name();
 #endif
     return name;
 }
@@ -141,8 +141,8 @@ to_string(T const& arg_) -> std::string {
  */
 template<typename T, SCTF_INTERN_ENABLE_IF(!SCTF_INTERN_HAS_STREAM_CAPABILITY(T, std::ostringstream))>
 auto
-to_string(T const&) -> std::string {
-    return name_for_type<T>();
+to_string(T const& arg_) -> std::string {
+    return name_for_type<T>(arg_);
 }
 
 /**

--- a/include/stringify.hpp
+++ b/include/stringify.hpp
@@ -25,6 +25,7 @@
 #include <algorithm>
 #include <iomanip>
 #include <limits>
+#include <memory>
 #include <sstream>
 #include <string>
 #include <typeinfo>
@@ -33,6 +34,10 @@
 #include "cpp_meta.hpp"
 #include "regex.hpp"
 #include "traits.hpp"
+
+#ifdef SCTF_SYS_UNIX
+#    include <cxxabi.h>
+#endif
 
 namespace sctf
 {
@@ -48,27 +53,15 @@ template<typename T>
 static auto
 name_for_type() -> std::string const& {
     static thread_local std::string name;
-    if (name.length() > 0) {
+    if (!name.empty()) {
         return name;
     }
 #ifdef SCTF_SYS_UNIX
-    std::string const sig(__PRETTY_FUNCTION__);
-    auto const        b = sig.rfind("T = ") + 4;
-    name                = sig.substr(b, sig.find_first_of(";]", b) - b);
-    name.erase(std::remove(name.begin(), name.end(), ' '), name.end());
+    int                     status = -1;
+    std::unique_ptr<char[]> sig(abi::__cxa_demangle(typeid(T).name(), nullptr, nullptr, &status));
+    name = sig.get();
 #else
-    std::string const sig(typeid(T).name());
-    auto              b = sig.find("struct ");
-    if (b != std::string::npos) {
-        name = sig.substr(b + 7);
-        return name;
-    }
-    b = sig.find("class ");
-    if (b != std::string::npos) {
-        name = sig.substr(b + 6);
-    } else {
-        name = std::move(sig);
-    }
+    name = typeid(T).name();
 #endif
     return name;
 }

--- a/release/build_header.sh
+++ b/release/build_header.sh
@@ -14,11 +14,11 @@ FILES="../include/cpp_meta.hpp
 ../include/testsuite/statistic.hpp
 ../include/testsuite/testsuite.hpp
 ../include/testsuite/testsuite_parallel.hpp
-../include/runner.hpp
 ../include/reporter/reporter.hpp
 ../include/reporter/xml_reporter.hpp
 ../include/reporter/console_reporter.hpp
 ../include/reporter/markdown_reporter.hpp
+../include/runner.hpp
 ../include/comparator/comparator.hpp
 ../include/comparator/ordering.hpp
 ../include/comparator/equality.hpp

--- a/test/reflexive_tests.cpp
+++ b/test/reflexive_tests.cpp
@@ -19,6 +19,7 @@
 
 #include <chrono>
 #include <cstddef>
+#include <iostream>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -270,12 +271,17 @@ SUITE_PAR("test_stringify") {
     class derived : public base
     {};
 
+    AFTER_EACH() {
+        std::cout << std::flush;
+    };
+
     TEST("bool") {
         ASSERT(to_string(true), EQ(), std::string("true"));
         ASSERT(to_string(false), EQ(), std::string("false"));
     };
     TEST("std_pair") {
         ASSERT(to_string(std::make_pair(1, 2)), LIKE(), "pair<int,\\s?int>"_re);
+        std::cout << to_string(std::make_pair(1, 2));
     };
     TEST("nullptr") {
         ASSERT(to_string(nullptr), EQ(), std::string("0"));
@@ -295,15 +301,18 @@ SUITE_PAR("test_stringify") {
     TEST("floating_point") {
         ASSERT(std::string("1.123"), IN(), to_string(1.123f));
         ASSERT(std::string("1.123"), IN(), to_string(1.123));
+        std::cout << to_string(1.234);
     };
     TEST("not_streamable") {
         ASSERT(to_string(not_streamable()), LIKE(), "not_streamable"_re);
+        std::cout << to_string(not_streamable());
     };
     TEST("streamable") {
         ASSERT(to_string(1), EQ(), std::string("1"));
     };
     TEST("derived") {
         ASSERT(to_string(derived()), LIKE(), "derived"_re);
+        std::cout << to_string(derived());
     };
 };
 

--- a/test/reflexive_tests.cpp
+++ b/test/reflexive_tests.cpp
@@ -267,7 +267,7 @@ SUITE_PAR("test_stringify") {
         ASSERT(to_string(false), EQ(), std::string("false"));
     };
     TEST("std_pair") {
-        ASSERT(std::string("pair<int,int>"), IN(), to_string(std::make_pair(1, 2)));
+        ASSERT(to_string(std::make_pair(1, 2)), LIKE(), "pair<int,\\s?int>"_re);
     };
     TEST("nullptr") {
         ASSERT(to_string(nullptr), EQ(), std::string("0"));
@@ -289,7 +289,7 @@ SUITE_PAR("test_stringify") {
         ASSERT(std::string("1.123"), IN(), to_string(1.123));
     };
     TEST("not_streamable") {
-        ASSERT(to_string(not_streamable()), EQ(), std::string("not_streamable"));
+        ASSERT(to_string(not_streamable()), LIKE(), "not_streamable"_re);
     };
     TEST("streamable") {
         ASSERT(to_string(1), EQ(), std::string("1"));

--- a/test/reflexive_tests.cpp
+++ b/test/reflexive_tests.cpp
@@ -262,6 +262,14 @@ SUITE_PAR("test_testcase") {
 };
 
 SUITE_PAR("test_stringify") {
+    class base
+    {
+    public:
+        virtual ~base() = default;
+    };
+    class derived : public base
+    {};
+
     TEST("bool") {
         ASSERT(to_string(true), EQ(), std::string("true"));
         ASSERT(to_string(false), EQ(), std::string("false"));
@@ -293,6 +301,9 @@ SUITE_PAR("test_stringify") {
     };
     TEST("streamable") {
         ASSERT(to_string(1), EQ(), std::string("1"));
+    };
+    TEST("derived") {
+        ASSERT(to_string(derived()), LIKE(), "derived"_re);
     };
 };
 


### PR DESCRIPTION
## Summary

Instead of parsing the __PRETTY_FUNCTION__ macro, use cxxabi for RTTI.

## Main changes

+ usage of cxxabi
+ drop equality constraint in name_for_type for all OSses.

## Related Issues/Milestones

